### PR TITLE
feat: add LiteLLM as AI gateway provider

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -25,6 +25,9 @@ setup(
         "deep-translator>=1.11.0",
     ],
     extras_require={
+        "litellm": [
+            "litellm>=1.80.0,<1.87.0",
+        ],
         "legacy": [
             # v1.0 methodology reference implementations (Method 3 detectors)
             "transformers>=4.36.0",

--- a/src/methodologies/llm_rewriter.py
+++ b/src/methodologies/llm_rewriter.py
@@ -34,6 +34,7 @@ class LLMRewriteProcessor:
         self.model = llm["model"]
         self.temperature = llm["temperature"]
         self.extra_headers = llm["extra_headers"]
+        self.provider = llm["provider"]
         self.top_p = self.config.get("top_p", 0.9)
         self.rounds = self.config.get("rounds", 2)
 
@@ -50,6 +51,7 @@ class LLMRewriteProcessor:
             top_p=self.top_p,
             timeout=60,
             extra_headers=self.extra_headers,
+            provider=self.provider,
         )
 
     def process(self, text: str, **kwargs) -> str:

--- a/src/standard/llm_client.py
+++ b/src/standard/llm_client.py
@@ -20,6 +20,12 @@ PROVIDER_DEFAULTS: dict[str, dict[str, str]] = {
         "api_key_field": "openrouter_api_key",
         "display_name": "OpenRouter",
     },
+    "litellm": {
+        "base_url": "",
+        "model": "deepseek/deepseek-chat",
+        "api_key_field": "litellm_api_key",
+        "display_name": "LiteLLM",
+    },
 }
 
 DEFAULT_PROVIDER = "deepseek"
@@ -71,7 +77,7 @@ def resolve_llm_config(config: dict) -> dict[str, Any]:
     elif provider == "deepseek" and (ds_key := os.environ.get("DEEPSEEK_API_KEY")):
         api_key = ds_key
 
-    if not api_key:
+    if not api_key and provider != "litellm":
         raise ValueError(
             f"Missing API key for provider {provider!r}. "
             f"Set api_keys.{api_key_field} in config or LLM_API_KEY env var."
@@ -104,8 +110,19 @@ def chat_completions(
     top_p: float | None = None,
     timeout: int = 120,
     extra_headers: dict | None = None,
+    provider: str | None = None,
 ) -> str:
     """Call an OpenAI-compatible /chat/completions endpoint."""
+    if provider == "litellm":
+        return _litellm_chat_completions(
+            messages,
+            api_key=api_key,
+            model=model,
+            temperature=temperature,
+            top_p=top_p,
+            timeout=timeout,
+        )
+
     if not api_key:
         raise ValueError("API key is required for LLM chat completions.")
 
@@ -125,3 +142,31 @@ def chat_completions(
     response = httpx.post(url, headers=headers, json=payload, timeout=timeout)
     response.raise_for_status()
     return response.json()["choices"][0]["message"]["content"].strip()
+
+
+def _litellm_chat_completions(
+    messages: list[dict],
+    *,
+    api_key: str,
+    model: str,
+    temperature: float = 1.3,
+    top_p: float | None = None,
+    timeout: int = 120,
+) -> str:
+    """Route through LiteLLM SDK for 100+ provider support."""
+    import litellm
+
+    kwargs: dict[str, Any] = {
+        "model": model,
+        "messages": messages,
+        "temperature": temperature,
+        "drop_params": True,
+        "timeout": timeout,
+    }
+    if api_key:
+        kwargs["api_key"] = api_key
+    if top_p is not None:
+        kwargs["top_p"] = top_p
+
+    response = litellm.completion(**kwargs)
+    return response.choices[0].message.content.strip()

--- a/src/standard/llm_rewriter.py
+++ b/src/standard/llm_rewriter.py
@@ -18,6 +18,7 @@ def llm_rewrite(
     history: dict | None = None,
     temperature: float = 1.3,
     extra_headers: dict | None = None,
+    provider: str | None = None,
 ) -> str:
     """Rewrite text into target language with humanization.
 
@@ -57,6 +58,7 @@ def llm_rewrite(
         model=model,
         temperature=temperature,
         extra_headers=extra_headers,
+        provider=provider,
     )
 
 

--- a/src/standard/pipeline.py
+++ b/src/standard/pipeline.py
@@ -53,6 +53,7 @@ def run_standard_pipeline(text: str, config: dict, target_lang: str = "en") -> d
         history=None,
         temperature=llm["temperature"],
         extra_headers=llm["extra_headers"],
+        provider=llm["provider"],
     )
     steps.append({
         "step": 1, "engine": engine_name,
@@ -70,6 +71,7 @@ def run_standard_pipeline(text: str, config: dict, target_lang: str = "en") -> d
         history={"input": text, "output": step1},
         temperature=llm["temperature"],
         extra_headers=llm["extra_headers"],
+        provider=llm["provider"],
     )
     steps.append({
         "step": 2, "engine": engine_name,


### PR DESCRIPTION
## Summary

Adds LiteLLM as a third provider alongside DeepSeek and OpenRouter, giving users access to 100+ LLM providers (Anthropic, OpenAI, Bedrock, Vertex AI, Groq, etc.) through a single `provider = "litellm"` config change.

## Motivation

The current provider system supports DeepSeek and OpenRouter. LiteLLM adds 100+ providers via its SDK without needing a separate proxy. Users set `provider = "litellm"` in `config.toml`, pick any model string (e.g. `anthropic/claude-sonnet-4-6`), and LiteLLM routes to the right provider using standard env vars (`ANTHROPIC_API_KEY`, `OPENAI_API_KEY`, etc.). `drop_params=True` handles cross-provider kwarg incompatibilities automatically.

## Changes

- `src/standard/llm_client.py` -- added `"litellm"` to `PROVIDER_DEFAULTS`, new `_litellm_chat_completions()` function using `litellm.completion()` with `drop_params=True`, `provider` kwarg threaded through `chat_completions()`
- `src/standard/llm_rewriter.py` -- forwards `provider` kwarg
- `src/standard/pipeline.py` -- forwards `provider` kwarg to both rewrite steps
- `src/methodologies/llm_rewriter.py` -- forwards `provider` kwarg

## Tests

**Existing tests (12/12 pass):**
```
tests/test_llm_client.py  12 passed in 0.02s
```

**Live E2E (LiteLLM SDK -> Azure Foundry -> Claude Sonnet 4.6):**
```
Response: '4'
=== E2E PASSED ===
```

## Example usage

```toml
# config.toml
[llm]
provider = "litellm"
model = "anthropic/claude-sonnet-4-6"
```

```bash
# LiteLLM reads provider API keys from env vars
export ANTHROPIC_API_KEY="sk-ant-..."
python examples/example_usage.py
```

```python
from src.standard.llm_client import resolve_llm_config, chat_completions

config = {
    "llm": {"provider": "litellm", "model": "anthropic/claude-sonnet-4-6"},
    "api_keys": {},  # litellm reads ANTHROPIC_API_KEY from env
}
llm = resolve_llm_config(config)

result = chat_completions(
    [{"role": "user", "content": "Rewrite this naturally: The experiment was conducted."}],
    api_key=llm["api_key"],
    base_url=llm["base_url"],
    model=llm["model"],
    temperature=llm["temperature"],
    provider=llm["provider"],
)
print(result)
# "We ran the experiment." (or similar humanized output)
```

Any [LiteLLM-supported model string](https://docs.litellm.ai/docs/providers) works: `openai/gpt-4o`, `groq/llama-3.3-70b-versatile`, `deepseek/deepseek-chat`, `bedrock/anthropic.claude-v2`, etc.
