### PR TITLE
Add Atlas Cloud LLM provider

### DIFF
--- a/README-zh.md
+++ b/README-zh.md
@@ -156,6 +156,18 @@ provider = "openrouter"
 model = "deepseek/deepseek-chat"
 ```
 
+**Atlas Cloud：**
+
+```toml
+[api_keys]
+atlascloud_api_key = "ak-..."
+niutrans_api_key = "your-key"
+
+[llm]
+provider = "atlascloud"
+model = "qwen/qwen3.5-flash"
+```
+
 可通过 `[llm].base_url` 或环境变量 `LLM_BASE_URL` / `LLM_API_KEY` 覆盖 API 端点。完整说明见 [docs/configuration.md](docs/configuration.md)。
 
 ### n8n 工作流

--- a/README.md
+++ b/README.md
@@ -141,6 +141,18 @@ provider = "openrouter"
 model = "deepseek/deepseek-chat"   # any OpenRouter model slug
 ```
 
+**Atlas Cloud:**
+
+```toml
+[api_keys]
+atlascloud_api_key = "ak-..."
+niutrans_api_key = "your-key"
+
+[llm]
+provider = "atlascloud"
+model = "qwen/qwen3.5-flash"
+```
+
 Override the API endpoint with `base_url` in `[llm]`, or via `LLM_BASE_URL` / `LLM_API_KEY` environment variables. Full reference: [docs/configuration.md](docs/configuration.md).
 
 ### n8n Workflow
@@ -249,6 +261,5 @@ MIT License. See [LICENSE](LICENSE) for details.
 
 - [MoneyPrinterTurbo](https://github.com/harry0703/MoneyPrinterTurbo) — AI short video generator
 - [AiToEarn](https://github.com/yikart/AiToEarn) — AI content publishing tool
-
 
 

--- a/config/config.example.toml
+++ b/config/config.example.toml
@@ -11,11 +11,13 @@ log_level = "info"
 deepseek_api_key = ""
 # OpenRouter API key (required when llm.provider = "openrouter")
 openrouter_api_key = ""
+# Atlas Cloud API key (required when llm.provider = "atlascloud")
+atlascloud_api_key = ""
 # Niutrans API key (required for Step 4: 二轮翻译)
 niutrans_api_key = ""
 
 [llm]
-# LLM provider: "deepseek" | "openrouter"
+# LLM provider: "deepseek" | "openrouter" | "atlascloud"
 provider = "deepseek"
 # Override API base URL (empty = provider default)
 base_url = ""

--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -62,7 +62,7 @@ Steps 1–2 use an OpenAI-compatible chat API configured in `config.toml` under 
 
 ```toml
 [llm]
-provider = "deepseek"     # or "openrouter"
+provider = "deepseek"     # "deepseek", "openrouter", or "atlascloud"
 base_url = ""             # empty = provider default; override for custom endpoints
 model = ""                # empty = provider default model
 temperature = 1.3
@@ -77,7 +77,7 @@ llm = resolve_llm_config(config)
 # llm["provider"], llm["base_url"], llm["model"], llm["api_key"], llm["display_name"]
 ```
 
-See [configuration.md](configuration.md) for API keys, OpenRouter model slugs, and env overrides (`LLM_PROVIDER`, `LLM_BASE_URL`, `OPENROUTER_API_KEY`, etc.).
+See [configuration.md](configuration.md) for API keys, provider model slugs, and env overrides (`LLM_PROVIDER`, `LLM_BASE_URL`, `OPENROUTER_API_KEY`, `ATLASCLOUD_API_KEY`, etc.).
 
 ---
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -37,12 +37,26 @@ provider = "openrouter"
 model = "deepseek/deepseek-chat"   # or anthropic/claude-3.5-sonnet, etc.
 ```
 
+#### Atlas Cloud (optional)
+
+Atlas Cloud exposes LLMs through an OpenAI-compatible endpoint.
+
+```toml
+[api_keys]
+atlascloud_api_key = "ak-..."
+
+[llm]
+provider = "atlascloud"
+model = "qwen/qwen3.5-flash"
+```
+
 #### Provider defaults
 
 | Provider | Default `base_url` | Default `model` | Config key |
 |----------|-------------------|-----------------|------------|
 | `deepseek` | `https://api.deepseek.com` | `deepseek-chat` | `api_keys.deepseek_api_key` |
 | `openrouter` | `https://openrouter.ai/api/v1` | `deepseek/deepseek-chat` | `api_keys.openrouter_api_key` |
+| `atlascloud` | `https://api.atlascloud.ai/v1` | `qwen/qwen3.5-flash` | `api_keys.atlascloud_api_key` |
 
 Set `base_url` in `[llm]` to override the provider preset (e.g. a self-hosted OpenAI-compatible proxy). Leave empty to use the default for the selected provider.
 
@@ -73,10 +87,11 @@ log_level = "info"        # debug, info, warning, error
 [api_keys]
 deepseek_api_key = ""     # Required when llm.provider = "deepseek"
 openrouter_api_key = ""   # Required when llm.provider = "openrouter"
+atlascloud_api_key = ""   # Required when llm.provider = "atlascloud"
 niutrans_api_key = ""     # Required
 
 [llm]
-provider = "deepseek"     # "deepseek" | "openrouter"
+provider = "deepseek"     # "deepseek" | "openrouter" | "atlascloud"
 base_url = ""             # empty = provider default; set to override
 model = ""                # empty = provider default model
 temperature = 1.3         # 1.1-1.5 range (1.3 recommended)
@@ -95,11 +110,12 @@ Optional runtime overrides (take precedence over TOML):
 
 | Variable | Purpose |
 |----------|---------|
-| `LLM_PROVIDER` | `deepseek` or `openrouter` |
+| `LLM_PROVIDER` | `deepseek`, `openrouter`, or `atlascloud` |
 | `LLM_BASE_URL` | Override API base URL |
 | `LLM_API_KEY` | Generic API key override |
 | `OPENROUTER_API_KEY` | OpenRouter key when provider is `openrouter` |
 | `DEEPSEEK_API_KEY` | DeepSeek key when provider is `deepseek` |
+| `ATLASCLOUD_API_KEY` | Atlas Cloud key when provider is `atlascloud` |
 | `LLM_MODEL` | Override model slug |
 
 **Example — switch to OpenRouter via environment (no TOML edit):**

--- a/docs/pipeline.md
+++ b/docs/pipeline.md
@@ -64,9 +64,9 @@ Finnish was selected for the intermediate step because of its agglutinative morp
 
 | Parameter | Value | Why |
 |-----------|-------|-----|
-| LLM provider | `deepseek` (default) or `openrouter` | Set via `[llm].provider` in `config.toml`. Both use OpenAI-compatible `/chat/completions`. |
+| LLM provider | `deepseek` (default), `openrouter`, or `atlascloud` | Set via `[llm].provider` in `config.toml`. All use OpenAI-compatible `/chat/completions`. |
 | Temperature | 1.3 | Higher than default (1.0) to increase creative variation. Too high (>1.5) causes incoherence. |
-| Model | Provider default or `[llm].model` | `deepseek-chat` (DeepSeek) or `deepseek/deepseek-chat` (OpenRouter). Any compatible model slug works. |
+| Model | Provider default or `[llm].model` | `deepseek-chat` (DeepSeek), `deepseek/deepseek-chat` (OpenRouter), or `qwen/qwen3.5-flash` (Atlas Cloud). Any compatible model slug works. |
 | Base URL | Provider default or `[llm].base_url` | Override to point at a custom OpenAI-compatible proxy. |
 | History | 1 round | Step 2 sees Step 1's context. More rounds didn't improve quality in testing. |
 | Intermediate language | `fi` (Finnish) | Configurable via `[pipeline].intermediate_lang` in `config.toml`. |

--- a/src/standard/llm_client.py
+++ b/src/standard/llm_client.py
@@ -20,6 +20,12 @@ PROVIDER_DEFAULTS: dict[str, dict[str, str]] = {
         "api_key_field": "openrouter_api_key",
         "display_name": "OpenRouter",
     },
+    "atlascloud": {
+        "base_url": "https://api.atlascloud.ai/v1",
+        "model": "qwen/qwen3.5-flash",
+        "api_key_field": "atlascloud_api_key",
+        "display_name": "Atlas Cloud",
+    },
     "litellm": {
         "base_url": "",
         "model": "deepseek/deepseek-chat",
@@ -76,6 +82,11 @@ def resolve_llm_config(config: dict) -> dict[str, Any]:
         api_key = or_key
     elif provider == "deepseek" and (ds_key := os.environ.get("DEEPSEEK_API_KEY")):
         api_key = ds_key
+    elif provider == "atlascloud" and (
+        atlas_key := os.environ.get("ATLASCLOUD_API_KEY")
+        or os.environ.get("ATLAS_CLOUD_API_KEY")
+    ):
+        api_key = atlas_key
 
     if not api_key and provider != "litellm":
         raise ValueError(

--- a/tests/test_llm_client.py
+++ b/tests/test_llm_client.py
@@ -41,6 +41,19 @@ def test_openrouter_provider():
     assert llm["display_name"] == "OpenRouter"
 
 
+def test_atlascloud_provider():
+    config = {
+        "api_keys": {"atlascloud_api_key": "ak-atlas-test"},
+        "llm": {"provider": "atlascloud"},
+    }
+    llm = resolve_llm_config(config)
+    assert llm["provider"] == "atlascloud"
+    assert llm["base_url"] == "https://api.atlascloud.ai/v1"
+    assert llm["model"] == "qwen/qwen3.5-flash"
+    assert llm["api_key"] == "ak-atlas-test"
+    assert llm["display_name"] == "Atlas Cloud"
+
+
 def test_base_url_override():
     config = {
         "api_keys": {"openrouter_api_key": "sk-or-test"},
@@ -87,6 +100,16 @@ def test_llm_api_key_env_overrides_provider_key(monkeypatch):
     monkeypatch.setenv("LLM_API_KEY", "generic-override")
     llm = resolve_llm_config(config)
     assert llm["api_key"] == "generic-override"
+
+
+def test_atlascloud_env_key(monkeypatch):
+    config = {
+        "api_keys": {},
+        "llm": {"provider": "atlascloud"},
+    }
+    monkeypatch.setenv("ATLASCLOUD_API_KEY", "env-atlas-key")
+    llm = resolve_llm_config(config)
+    assert llm["api_key"] == "env-atlas-key"
 
 
 def test_missing_api_key_raises():


### PR DESCRIPTION
## Summary\n- add Atlas Cloud as a built-in OpenAI-compatible LLM provider preset\n- support atlascloud_api_key plus ATLASCLOUD_API_KEY / ATLAS_CLOUD_API_KEY env fallbacks\n- update config/docs examples and focused config-resolution tests\n\n## Validation\n- python3 -m pytest tests/test_llm_client.py -q\n- python3 -m py_compile src/standard/llm_client.py src/standard/pipeline.py tests/test_llm_client.py\n- git diff --check\n- confirmed Atlas Cloud live model catalog includes qwen/qwen3.5-flash and deepseek-ai/deepseek-v4-pro\n\nREADME/docs updates are limited to existing technical provider configuration sections; no sponsor/logo/credits/partner content was added.