### PR TITLE
feat: add OrcaRouter as an LLM provider

### DIFF
--- a/README-zh.md
+++ b/README-zh.md
@@ -168,6 +168,18 @@ provider = "atlascloud"
 model = "qwen/qwen3.5-flash"
 ```
 
+**OrcaRouter：**
+
+```toml
+[api_keys]
+orcarouter_api_key = "sk-orca-..."
+niutrans_api_key = "your-key"
+
+[llm]
+provider = "orcarouter"
+model = "deepseek/deepseek-chat"
+```
+
 可通过 `[llm].base_url` 或环境变量 `LLM_BASE_URL` / `LLM_API_KEY` 覆盖 API 端点。完整说明见 [docs/configuration.md](docs/configuration.md)。
 
 ### n8n 工作流

--- a/README.md
+++ b/README.md
@@ -181,6 +181,18 @@ provider = "atlascloud"
 model = "qwen/qwen3.5-flash"
 ```
 
+**OrcaRouter:**
+
+```toml
+[api_keys]
+orcarouter_api_key = "sk-orca-..."
+niutrans_api_key = "your-key"
+
+[llm]
+provider = "orcarouter"
+model = "deepseek/deepseek-chat"   # any OrcaRouter model slug
+```
+
 Override the API endpoint with `base_url` in `[llm]`, or via `LLM_BASE_URL` / `LLM_API_KEY` environment variables. Full reference: [docs/configuration.md](docs/configuration.md).
 
 ### n8n Workflow

--- a/config/config.example.toml
+++ b/config/config.example.toml
@@ -13,11 +13,13 @@ deepseek_api_key = ""
 openrouter_api_key = ""
 # Atlas Cloud API key (required when llm.provider = "atlascloud")
 atlascloud_api_key = ""
+# OrcaRouter API key (required when llm.provider = "orcarouter")
+orcarouter_api_key = ""
 # Niutrans API key (required for Step 4: 二轮翻译)
 niutrans_api_key = ""
 
 [llm]
-# LLM provider: "deepseek" | "openrouter" | "atlascloud"
+# LLM provider: "deepseek" | "openrouter" | "atlascloud" | "orcarouter"
 provider = "deepseek"
 # Override API base URL (empty = provider default)
 base_url = ""

--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -62,7 +62,7 @@ Steps 1–2 use an OpenAI-compatible chat API configured in `config.toml` under 
 
 ```toml
 [llm]
-provider = "deepseek"     # "deepseek", "openrouter", or "atlascloud"
+provider = "deepseek"     # "deepseek", "openrouter", "atlascloud", or "orcarouter"
 base_url = ""             # empty = provider default; override for custom endpoints
 model = ""                # empty = provider default model
 temperature = 1.3
@@ -77,7 +77,7 @@ llm = resolve_llm_config(config)
 # llm["provider"], llm["base_url"], llm["model"], llm["api_key"], llm["display_name"]
 ```
 
-See [configuration.md](configuration.md) for API keys, provider model slugs, and env overrides (`LLM_PROVIDER`, `LLM_BASE_URL`, `OPENROUTER_API_KEY`, `ATLASCLOUD_API_KEY`, etc.).
+See [configuration.md](configuration.md) for API keys, provider model slugs, and env overrides (`LLM_PROVIDER`, `LLM_BASE_URL`, `OPENROUTER_API_KEY`, `ATLASCLOUD_API_KEY`, `ORCAROUTER_API_KEY`, etc.).
 
 ---
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -50,6 +50,19 @@ provider = "atlascloud"
 model = "qwen/qwen3.5-flash"
 ```
 
+#### OrcaRouter (optional)
+
+[OrcaRouter](https://www.orcarouter.ai) exposes many models via a single OpenAI-compatible routing gateway.
+
+```toml
+[api_keys]
+orcarouter_api_key = "sk-orca-..."
+
+[llm]
+provider = "orcarouter"
+model = "deepseek/deepseek-chat"
+```
+
 #### Provider defaults
 
 | Provider | Default `base_url` | Default `model` | Config key |
@@ -57,6 +70,7 @@ model = "qwen/qwen3.5-flash"
 | `deepseek` | `https://api.deepseek.com` | `deepseek-chat` | `api_keys.deepseek_api_key` |
 | `openrouter` | `https://openrouter.ai/api/v1` | `deepseek/deepseek-chat` | `api_keys.openrouter_api_key` |
 | `atlascloud` | `https://api.atlascloud.ai/v1` | `qwen/qwen3.5-flash` | `api_keys.atlascloud_api_key` |
+| `orcarouter` | `https://api.orcarouter.ai/v1` | `deepseek/deepseek-chat` | `api_keys.orcarouter_api_key` |
 
 Set `base_url` in `[llm]` to override the provider preset (e.g. a self-hosted OpenAI-compatible proxy). Leave empty to use the default for the selected provider.
 
@@ -88,10 +102,11 @@ log_level = "info"        # debug, info, warning, error
 deepseek_api_key = ""     # Required when llm.provider = "deepseek"
 openrouter_api_key = ""   # Required when llm.provider = "openrouter"
 atlascloud_api_key = ""   # Required when llm.provider = "atlascloud"
+orcarouter_api_key = ""   # Required when llm.provider = "orcarouter"
 niutrans_api_key = ""     # Required
 
 [llm]
-provider = "deepseek"     # "deepseek" | "openrouter" | "atlascloud"
+provider = "deepseek"     # "deepseek" | "openrouter" | "atlascloud" | "orcarouter"
 base_url = ""             # empty = provider default; set to override
 model = ""                # empty = provider default model
 temperature = 1.3         # 1.1-1.5 range (1.3 recommended)
@@ -110,12 +125,13 @@ Optional runtime overrides (take precedence over TOML):
 
 | Variable | Purpose |
 |----------|---------|
-| `LLM_PROVIDER` | `deepseek`, `openrouter`, or `atlascloud` |
+| `LLM_PROVIDER` | `deepseek`, `openrouter`, `atlascloud`, or `orcarouter` |
 | `LLM_BASE_URL` | Override API base URL |
 | `LLM_API_KEY` | Generic API key override |
 | `OPENROUTER_API_KEY` | OpenRouter key when provider is `openrouter` |
 | `DEEPSEEK_API_KEY` | DeepSeek key when provider is `deepseek` |
 | `ATLASCLOUD_API_KEY` | Atlas Cloud key when provider is `atlascloud` |
+| `ORCAROUTER_API_KEY` | OrcaRouter key when provider is `orcarouter` |
 | `LLM_MODEL` | Override model slug |
 
 **Example — switch to OpenRouter via environment (no TOML edit):**

--- a/docs/pipeline.md
+++ b/docs/pipeline.md
@@ -64,9 +64,9 @@ Finnish was selected for the intermediate step because of its agglutinative morp
 
 | Parameter | Value | Why |
 |-----------|-------|-----|
-| LLM provider | `deepseek` (default), `openrouter`, or `atlascloud` | Set via `[llm].provider` in `config.toml`. All use OpenAI-compatible `/chat/completions`. |
+| LLM provider | `deepseek` (default), `openrouter`, `atlascloud`, or `orcarouter` | Set via `[llm].provider` in `config.toml`. All use OpenAI-compatible `/chat/completions`. |
 | Temperature | 1.3 | Higher than default (1.0) to increase creative variation. Too high (>1.5) causes incoherence. |
-| Model | Provider default or `[llm].model` | `deepseek-chat` (DeepSeek), `deepseek/deepseek-chat` (OpenRouter), or `qwen/qwen3.5-flash` (Atlas Cloud). Any compatible model slug works. |
+| Model | Provider default or `[llm].model` | `deepseek-chat` (DeepSeek), `deepseek/deepseek-chat` (OpenRouter), `qwen/qwen3.5-flash` (Atlas Cloud), or `deepseek/deepseek-chat` (OrcaRouter). Any compatible model slug works. |
 | Base URL | Provider default or `[llm].base_url` | Override to point at a custom OpenAI-compatible proxy. |
 | History | 1 round | Step 2 sees Step 1's context. More rounds didn't improve quality in testing. |
 | Intermediate language | `fi` (Finnish) | Configurable via `[pipeline].intermediate_lang` in `config.toml`. |

--- a/src/standard/llm_client.py
+++ b/src/standard/llm_client.py
@@ -26,6 +26,12 @@ PROVIDER_DEFAULTS: dict[str, dict[str, str]] = {
         "api_key_field": "atlascloud_api_key",
         "display_name": "Atlas Cloud",
     },
+    "orcarouter": {
+        "base_url": "https://api.orcarouter.ai/v1",
+        "model": "deepseek/deepseek-chat",
+        "api_key_field": "orcarouter_api_key",
+        "display_name": "OrcaRouter",
+    },
     "litellm": {
         "base_url": "",
         "model": "deepseek/deepseek-chat",
@@ -87,6 +93,8 @@ def resolve_llm_config(config: dict) -> dict[str, Any]:
         or os.environ.get("ATLAS_CLOUD_API_KEY")
     ):
         api_key = atlas_key
+    elif provider == "orcarouter" and (or_key := os.environ.get("ORCAROUTER_API_KEY")):
+        api_key = or_key
 
     if not api_key and provider != "litellm":
         raise ValueError(

--- a/tests/test_llm_client.py
+++ b/tests/test_llm_client.py
@@ -54,6 +54,19 @@ def test_atlascloud_provider():
     assert llm["display_name"] == "Atlas Cloud"
 
 
+def test_orcarouter_provider():
+    config = {
+        "api_keys": {"orcarouter_api_key": "sk-orca-test"},
+        "llm": {"provider": "orcarouter"},
+    }
+    llm = resolve_llm_config(config)
+    assert llm["provider"] == "orcarouter"
+    assert llm["base_url"] == "https://api.orcarouter.ai/v1"
+    assert llm["model"] == "deepseek/deepseek-chat"
+    assert llm["api_key"] == "sk-orca-test"
+    assert llm["display_name"] == "OrcaRouter"
+
+
 def test_base_url_override():
     config = {
         "api_keys": {"openrouter_api_key": "sk-or-test"},
@@ -110,6 +123,16 @@ def test_atlascloud_env_key(monkeypatch):
     monkeypatch.setenv("ATLASCLOUD_API_KEY", "env-atlas-key")
     llm = resolve_llm_config(config)
     assert llm["api_key"] == "env-atlas-key"
+
+
+def test_orcarouter_env_key(monkeypatch):
+    config = {
+        "api_keys": {},
+        "llm": {"provider": "orcarouter"},
+    }
+    monkeypatch.setenv("ORCAROUTER_API_KEY", "env-orca-key")
+    llm = resolve_llm_config(config)
+    assert llm["api_key"] == "env-orca-key"
 
 
 def test_missing_api_key_raises():


### PR DESCRIPTION
## Summary

This registers [OrcaRouter](https://www.orcarouter.ai) the same way the existing OpenRouter and Atlas Cloud providers are wired, so the config reference and docs stay consistent. OrcaRouter is an OpenAI-compatible gateway: one `ORCAROUTER_API_KEY` (keys start with `sk-orca-`) unlocks 150+ models from OpenAI, Anthropic, Google, DeepSeek, Qwen, MiniMax and xAI behind a single `https://api.orcarouter.ai/v1` endpoint. It also runs gateway-level, zero-trust security for AI agents on the same endpoint - screening every prompt/response and governing every tool call on a default-deny basis, with no application code changes.

I'm an engineer on the OrcaRouter team.

## What this changes

- `src/standard/llm_client.py`: registers the `orcarouter` provider in `PROVIDER_DEFAULTS` (base URL `https://api.orcarouter.ai/v1`, default model `deepseek/deepseek-chat`, config key `orcarouter_api_key`), with an `ORCAROUTER_API_KEY` env fallback
- `config/config.example.toml`: adds `orcarouter_api_key` and updates the provider comment
- `README.md` / `README-zh.md`: adds an OrcaRouter config block alongside the existing providers
- `docs/configuration.md`: adds an OrcaRouter section, provider-defaults table row, and env-var row
- `docs/api-reference.md` / `docs/pipeline.md`: documents the new provider and default model
- `tests/test_llm_client.py`: adds `test_orcarouter_provider` and `test_orcarouter_env_key`

## How to use it

1. Get an API key at https://www.orcarouter.ai/console (keys start with `sk-orca-`).
2. Set `orcarouter_api_key` in `config/config.toml`, or `ORCAROUTER_API_KEY` as an env var.
3. Set `[llm] provider = "orcarouter"` (the default model is `deepseek/deepseek-chat`; any OrcaRouter model slug works).

## Validation

- Unit tests: `pytest tests/ -q` -> 28 passed (includes the 2 new OrcaRouter tests)
- `python -m py_compile` on the changed Python files + `git diff --check` clean
- Live API with a real key through the repo's own `resolve_llm_config` + `chat_completions` path: default model 200, `orcarouter/auto` 200, invalid key 401
- Confirmed `deepseek/deepseek-chat` is present in the live OrcaRouter model catalog

README/docs updates are limited to existing technical provider configuration sections; no sponsor/logo/credits/partner content was added.
